### PR TITLE
feat: 게시판 댓글 CRUD 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 			<version>${org.aspectj-version}</version>
 		</dependency>
 
-		<!-- Logging (log4j 1.2.17)-->
+		<!-- Logging (log4j 1.2.17) -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
@@ -131,7 +131,7 @@
 			<version>1</version>
 		</dependency>
 
-		<!-- Servlet 3.1.0-->
+		<!-- Servlet 3.1.0 -->
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
@@ -150,6 +150,27 @@
 			<version>1.2</version>
 		</dependency>
 
+		<!-- 브라우저에 객체를 JSON 포맷의 문자열로 변환시켜 전송할때 필요 -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.9.4</version>
+		</dependency>
+
+		<!-- XML 처리 -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+			<version>2.9.6</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+		<!-- Java인스턴스를 JSON타입 문자열로 변환 -->
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.2</version>
+		</dependency>
 
 
 		<dependency>
@@ -164,11 +185,7 @@
 			<version>1.3.3</version>
 		</dependency>
 
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.9.4</version>
-		</dependency>
+
 
 	</dependencies>
 	<build>

--- a/src/main/java/com/cgkim449/app/controller/ReplyController.java
+++ b/src/main/java/com/cgkim449/app/controller/ReplyController.java
@@ -1,0 +1,87 @@
+package com.cgkim449.app.controller;
+
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import com.cgkim449.app.domain.Criteria;
+import com.cgkim449.app.domain.ReplyVO;
+import com.cgkim449.app.service.ReplyService;
+import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j;
+
+@RequestMapping("/replies")
+@RestController
+@Log4j
+@AllArgsConstructor
+public class ReplyController {
+  private ReplyService service;
+
+  @PostMapping(value="/new",
+      consumes="application/json",
+      produces= {MediaType.TEXT_PLAIN_VALUE})
+  public ResponseEntity<String> create(@RequestBody ReplyVO vo) {
+    log.info("ReplyVO: " + vo);
+    int insertCount = service.register(vo);
+    log.info("Reply Insert Count" + insertCount);
+
+    return insertCount == 1 
+        ? new ResponseEntity<>("success", HttpStatus.OK) 
+            : new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @GetMapping(value="/pages/{bno}/{page}", 
+      produces= {
+          MediaType.APPLICATION_XML_VALUE,
+          MediaType.APPLICATION_JSON_UTF8_VALUE})
+  public ResponseEntity<List<ReplyVO>> getList(    
+      @PathVariable("page") int page,
+      @PathVariable("bno") Long bno){
+    log.info("getList...");
+    Criteria cri = new Criteria(page, 10);
+    log.info(cri);
+    return new ResponseEntity<>(service.getList(cri, bno), HttpStatus.OK);
+  }
+
+  @GetMapping(value="/{rno}", 
+      produces = {MediaType.APPLICATION_ATOM_XML_VALUE,
+          MediaType.APPLICATION_JSON_UTF8_VALUE
+  })
+  public ResponseEntity<ReplyVO> get(@PathVariable("rno") Long rno) {
+    log.info("get: " + rno);
+    return new ResponseEntity<>(service.get(rno), HttpStatus.OK);
+  }
+
+  @DeleteMapping(value="/{rno}", produces= {MediaType.TEXT_PLAIN_VALUE})
+  public ResponseEntity<String> remove(@PathVariable("rno") Long rno) {
+    log.info("remove: " + rno);
+
+    return service.remove(rno) == 1
+        ? new ResponseEntity<String>("success", HttpStatus.OK)
+            : new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @RequestMapping(method= {RequestMethod.PUT, RequestMethod.PATCH},
+      value = "/{rno}",
+      consumes="application/json",
+      produces= {MediaType.TEXT_PLAIN_VALUE})
+  public ResponseEntity<String> modify(
+      @RequestBody ReplyVO vo,
+      @PathVariable("rno") Long rno) {
+    vo.setRno(rno);
+    log.info("rno: " + rno);
+    log.info("modify: " + vo);
+
+    return service.modify(vo) == 1
+        ? new ResponseEntity<String>("success", HttpStatus.OK)
+            : new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+}

--- a/src/main/java/com/cgkim449/app/domain/ReplyVO.java
+++ b/src/main/java/com/cgkim449/app/domain/ReplyVO.java
@@ -1,0 +1,15 @@
+package com.cgkim449.app.domain;
+
+import java.util.Date;
+import lombok.Data;
+
+@Data
+public class ReplyVO {
+  private Long rno;
+  private Long bno;
+
+  private String reply;
+  private String replyer;
+  private Date replyDate;
+  private Date updateDate;
+}

--- a/src/main/java/com/cgkim449/app/mapper/ReplyMapper.java
+++ b/src/main/java/com/cgkim449/app/mapper/ReplyMapper.java
@@ -1,0 +1,18 @@
+package com.cgkim449.app.mapper;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Param;
+import com.cgkim449.app.domain.Criteria;
+import com.cgkim449.app.domain.ReplyVO;
+
+public interface ReplyMapper {
+  int insert(ReplyVO vo);
+  ReplyVO read(Long rno); // 특정 댓글 읽기
+  int delete(int rno);
+  int update(ReplyVO reply);
+
+  public List<ReplyVO> getListWithPaging(
+      @Param("cri") Criteria cri,
+      @Param("bno") Long bno);
+  // Criteria와, 그리고 추가적으로 해당 게시물의 번호가 필요하다
+}

--- a/src/main/java/com/cgkim449/app/mapper/ReplyMapper.java
+++ b/src/main/java/com/cgkim449/app/mapper/ReplyMapper.java
@@ -8,7 +8,7 @@ import com.cgkim449.app.domain.ReplyVO;
 public interface ReplyMapper {
   int insert(ReplyVO vo);
   ReplyVO read(Long rno); // 특정 댓글 읽기
-  int delete(int rno);
+  int delete(Long rno);
   int update(ReplyVO reply);
 
   public List<ReplyVO> getListWithPaging(

--- a/src/main/java/com/cgkim449/app/service/ReplyService.java
+++ b/src/main/java/com/cgkim449/app/service/ReplyService.java
@@ -1,0 +1,13 @@
+package com.cgkim449.app.service;
+
+import java.util.List;
+import com.cgkim449.app.domain.Criteria;
+import com.cgkim449.app.domain.ReplyVO;
+
+public interface ReplyService {
+  int register(ReplyVO vo);
+  ReplyVO get(Long rno);
+  int modify(ReplyVO vo);
+  int remove(Long rno);
+  List<ReplyVO> getList(Criteria cri, Long bno);
+}

--- a/src/main/java/com/cgkim449/app/service/ReplyServiceImpl.java
+++ b/src/main/java/com/cgkim449/app/service/ReplyServiceImpl.java
@@ -1,0 +1,50 @@
+package com.cgkim449.app.service;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import com.cgkim449.app.domain.Criteria;
+import com.cgkim449.app.domain.ReplyVO;
+import com.cgkim449.app.mapper.ReplyMapper;
+import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j;
+
+@Service
+@Log4j
+@AllArgsConstructor
+public class ReplyServiceImpl implements ReplyService{
+
+  private ReplyMapper mapper;
+
+  @Override
+  public int register(ReplyVO vo) {
+    log.info("register..." + vo);
+    return mapper.insert(vo);
+  }
+
+  @Override
+  public ReplyVO get(Long rno) {
+    log.info("get...." + rno) ;
+    return mapper.read(rno);
+  }
+
+  @Override
+  public int modify(ReplyVO vo) {
+    log.info("modify..." + vo);
+    return mapper.update(vo);
+  }
+
+  @Override
+  public int remove(Long rno) {
+    log.info("remove..."+rno);
+    return mapper.delete(rno);
+  }
+
+  @Override
+  public List<ReplyVO> getList(Criteria cri, Long bno) {
+    log.info("getList..." + bno);
+    return mapper.getListWithPaging(cri, bno);
+  }
+
+}

--- a/src/main/resources/com/cgkim449/app/mapper/BoardMapper.xml
+++ b/src/main/resources/com/cgkim449/app/mapper/BoardMapper.xml
@@ -7,22 +7,22 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 
 <sql id="criteria">
 <trim prefix="(" suffix=") AND " prefixOverrides="OR">
-         <foreach item="type" collection="typeArr">
-           <trim prefix="OR">
-             <choose>
-               <when test="type=='T'.toString()">
-                 title like '%'||#{keyword}||'%'
-               </when>
-               <when test="type=='C'.toString()">
-                 content like '%'||#{keyword}||'%'
-               </when>
-               <when test="type=='W'.toString()">
-                 writer like '%'||#{keyword}||'%'
-               </when>
-             </choose>
-           </trim>
-         </foreach>
-        </trim>
+ <foreach item="type" collection="typeArr">
+   <trim prefix="OR">
+     <choose>
+       <when test="type=='T'.toString()">
+         title like '%'||#{keyword}||'%'
+       </when>
+       <when test="type=='C'.toString()">
+         content like '%'||#{keyword}||'%'
+       </when>
+       <when test="type=='W'.toString()">
+         writer like '%'||#{keyword}||'%'
+       </when>
+     </choose>
+   </trim>
+ </foreach>
+</trim>
 </sql>
 
 	<select id="getList"

--- a/src/main/resources/com/cgkim449/app/mapper/ReplyMapper.xml
+++ b/src/main/resources/com/cgkim449/app/mapper/ReplyMapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.cgkim449.app.mapper.ReplyMapper">
+
+  <insert id="insert">
+    insert into tbl_reply(rno, bno, reply, replyer)
+    values(seq_reply.nextval, #{bno}, #{reply}, #{replyer})
+  </insert>
+  
+  <select id="read" resultType="com.cgkim449.app.domain.ReplyVO">
+    select * from tbl_reply where rno=#{rno}
+  </select>
+  
+  <delete id="delete">
+    delete from tbl_reply where rno=#{rno}
+  </delete>
+
+  <update id="update">
+    update tbl_reply set reply = #{reply}, updatedate = sysdate where rno = #{rno}
+  </update>
+  
+  <!-- 특정 게시물의 댓글을 가져온다 -->
+  <select id= "getListWithPaging"
+  resultType="com.cgkim449.app.domain.ReplyVO">
+    select rno, bno, reply, replyer, replyDate, updatedate
+    from tbl_reply
+    where bno=#{bno}
+    order by rno asc
+  </select>
+</mapper>

--- a/src/main/webapp/WEB-INF/views/board/get.jsp
+++ b/src/main/webapp/WEB-INF/views/board/get.jsp
@@ -8,7 +8,204 @@
 <meta charset="UTF-8">
 <title>게시글 조회</title>
 
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+
+<script type="text/javascript" src="/resources/js/reply.js"></script>
+
+<!-- <script type="text/javascript">
+$(document).ready(function() {
+	console.log(replyService);
+	console.log("=============");
+	console.log("JS TEST");
+	
+	var bnoValue = '<c:out value="${board.bno}"/>';
+	
+	replyService.add(
+			{reply: "JS Test", replyer:"tester", bno:bnoValue}
+			, 
+			function(result) {
+				alert("RESULT: " + result);
+			}
+		);
+});
+</script> -->
+
+<!-- <script type="text/javascript">
+$(document).ready(function() {
+	console.log(replyService);
+	console.log("=============");
+	console.log("JS TEST");
+	
+	var bnoValue = '<c:out value="${board.bno}"/>';
+	
+	replyService.getList(
+			{bno:bnoValue, page:1}, 
+			function(list) {
+				for(var i = 0, len = list.length||0; i < len; i++) {
+					console.log(list[i]);
+				}
+			}
+		);
+});
+</script>
+ -->
+ 
+<!-- <script type="text/javascript">
+$(document).ready(function() {
+	console.log(replyService);
+	console.log("=============");
+	console.log("JS TEST");
+	
+	var bnoValue = '<c:out value="${board.bno}"/>';
+	
+	replyService.remove(2, function(count) {
+		console.log(count);
+		if(count === "success") {
+			alert("REMOVED");
+		}
+	}, function(err) {
+		alert("err...");
+	});
+});
+</script> -->
+
+<!-- <script type="text/javascript">
+$(document).ready(function() {
+	console.log(replyService);
+	console.log("=============");
+	console.log("JS TEST");
+	
+	var bnoValue = '<c:out value="${board.bno}"/>';
+	
+	replyService.update({
+		rno: 3,
+		bno: bnoValue,
+		reply : "Modified Reply...."
+	}, function(result) {
+		alert("수정 완료...")
+	});
+});
+</script> -->
+
+<!-- <script type="text/javascript">
+$(document).ready(function() {
+	console.log(replyService);
+	console.log("=============");
+	console.log("JS TEST");
+	
+	/* var bnoValue = '<c:out value="${board.bno}"/>'; */
+	
+	replyService.get(3, function(data) {
+		console.log(data);
+	});
+});
+</script> -->
+
+<!-- 댓글 목록 -->
+<script>
+$(document).ready(function() {
+	var bnoValue='<c:out value="${board.bno}"/>';
+	var replyUL=$(".chat");
+	
+	showList(1);
+	
+	function showList(page) {
+		replyService.getList({bno:bnoValue, page: page || 1}, function(list) {
+			var str = "";
+			if(list==null||list.length==0) {
+				replyUL.html("");
+				return;
+			}
+			for(var i = 0, len = list.length || 0; i < len; i++) {
+				str +="<li data-rno='" + list[i].rno+"'>";
+				str +="  <strong>" + list[i].replyer + "</strong>";
+				str +="  <small>" + replyService.displayTime(list[i].replyDate) + "</small>";
+				str +="  <p>" + list[i].reply + "</p></li>";
+			}
+			replyUL.html(str);
+		}); // end function
+	} // end showList
+	
+	/*새댓글 모달*/
+	var modal = $(".modal");
+	var modalInputReply = modal.find("input[name='reply']");
+	var modalInputReplyer = modal.find("input[name='replyer']");
+	var modalInputReplyDate = modal.find("input[name='replyDate']");
+	
+	var modalModBtn = $("#modalModBtn");
+	var modalRemoveBtn = $("#modalRemoveBtn");
+	var modalRegisterBtn = $("#modalRegisterBtn");
+	
+	$("#addReplyBtn").on("click", function(e) {
+		modal.find("input").val("");
+		modalInputReplyDate.closest("div").hide();
+		modal.find("button[id != 'modalCloseBtn']").hide();
+		
+		modalRegisterBtn.show();
+		
+		$(".modal").modal("show");
+	});
+	
+	modalRegisterBtn.on("click", function(e) {
+		var reply = {
+				reply: modalInputReply.val(),
+				replyer: modalInputReplyer.val(),
+				bno: bnoValue
+		};
+		replyService.add(reply, function(result) {
+			alert(result);
+			/*등록한 내용으로 다시 등록할 수 없도록 입력항목을 비운다*/
+			modal.find("input").val("");
+			modal.modal("hide");
+			
+			/*댓글 추가 후 댓글 목록 갱신*/
+			showList(1);
+		});
+	});
+	
+	/*댓글 클릭*/
+	/*on()을 이용하면 쉽게 이벤트 위임을 할 수 있다!*/
+	$(".chat").on("click", "li", function(e) {
+		/*this가 .chat이 아닌 li인 것이다*/
+		var rno = $(this).data("rno");
+		replyService.get(rno, function(reply) {
+			modalInputReply.val(reply.reply);
+			modalInputReplyer.val(reply.replyer);
+			modalInputReplyDate.val(replyService.displayTime(reply.replyDate)).attr("readonly", "readonly");
+			/*data-rno 속성을 만들어서 추가해둔다*/
+			modal.data("rno", reply.rno);
+			
+			modal.find("button[id != 'modalCloseBtn']").hide();
+			modalModBtn.show();
+			modalRemoveBtn.show();
+			
+			$(".modal").modal("show");
+		});
+	});
+	
+	modalModBtn.on("click", function(e) {
+		/*위에서 추가한 data-rno*/
+		var reply = {rno:modal.data("rno"), reply: modalInputReply.val()};
+		replyService.update(reply, function(result) {
+			alert(result);
+			modal.modal("hide");
+			showList(1);
+		});
+	});
+	
+	modalRemoveBtn.on("click", function(e) {
+		var rno = modal.data("rno");
+		replyService.remove(rno, function(result) {
+			alert(result);
+			modal.modal("hide");
+			showList(1);
+		});
+	});
+});
+</script>
+
 <script type="text/javascript">
 $(document).ready(function() {
 	var operForm = $("#operForm");
@@ -24,6 +221,7 @@ $(document).ready(function() {
 });
 </script>
 
+
 </head>
 <body>
 <h1>게시글 조회</h1>
@@ -33,7 +231,50 @@ $(document).ready(function() {
     <label>작성자</label> <input name="writer" value='<c:out value="${board.writer}"/>' readonly="readonly"><br>
     
     <button data-oper='modify'>수정</button>
-    <button data-oper='list'>목록</button>
+    <button data-oper='list'>목록</button><br>
+    
+		<button id='addReplyBtn' type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addReplyModal" data-bs-whatever="@mdo">새 댓글</button>
+    <!-- <button id='addReplyBtn'>새 댓글</button> -->
+    <!-- start reply -->
+    <ul class="chat">
+    </ul>
+    <!-- end reply -->
+    
+
+		<!-- start 새 댓글 modal -->
+		<div class="modal fade" id="addReplyModal" tabindex="-1" aria-labelledby="addReplyModalLabel" aria-hidden="true">
+		  <div class="modal-dialog">
+		    <div class="modal-content">
+		      <div class="modal-header">
+		        <h5 class="modal-title" id="addReplyModalLabel">새 댓글</h5>
+		        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+		      </div>
+		      <div class="modal-body">
+		        <!-- <form> -->
+		          <div class="mb-3">
+		            <label for="reply" class="col-form-label">내용:</label>
+		            <input class="form-control" name='reply' value="New Reply!!!">
+		          </div>
+		          <div class="mb-3">
+		            <label for="replyer" class="col-form-label">작성자:</label>
+		            <input class="form-control" name='replyer' value="replyer">
+		          </div>
+		          <div class="mb-3">
+		            <label for="replyDate" class="col-form-label">입력 날짜:</label>
+		            <input class="form-control" name='replyDate' value="replyDate">
+		          </div>
+		        <!-- </form> -->
+		      </div>
+		      <div class="modal-footer">
+		        <button id= 'modalCloseBtn' type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+		        <button id= 'modalModBtn' type="button" class="btn btn-warning">수정</button>
+		        <button id= 'modalRemoveBtn' type="button" class="btn btn-danger">삭제</button>
+		        <button id= 'modalRegisterBtn' type="button" class="btn btn-primary">등록</button>
+		      </div>
+		    </div>
+		  </div>
+		</div>
+		<!-- end 새댓글 modal -->
     
     <form id="operForm" action="/board/modify" method="get">
       <input type="hidden" id="bno" name="bno" value='<c:out value="${board.bno}"/>'>
@@ -42,5 +283,7 @@ $(document).ready(function() {
       <input type="hidden" name="keyword" value='<c:out value="${cri.keyword}"/>'>
       <input type="hidden" name="type" value='<c:out value="${cri.type}"/>'>
     </form>
+    
+
 </body>
 </html>

--- a/src/main/webapp/resources/js/reply.js
+++ b/src/main/webapp/resources/js/reply.js
@@ -1,0 +1,119 @@
+ console.log("Reply Module.....");
+ var replyService = (function() {
+  
+  function add(reply, callback, error) {
+    console.log("reply.......");
+    
+    $.ajax({
+      type:'post',
+      url:'/replies/new',
+      data:JSON.stringify(reply),
+      contentType:"application/json; charset=utf-8",
+      success:function(result, status, xhr) {
+        if(callback) { /*callback함수가 존재한다면?*/
+          callback(result);
+        }
+      },
+      error: function(xhr, status, er) {
+        if(error) {
+          error(er);
+        }
+      }
+    })
+  }
+  
+  function getList(param, callback, error) {
+    var bno = param.bno;
+    var page = param.page || 1;
+    $.getJSON("/replies/pages/" + bno + "/" + page + ".json",
+    function(data) {
+      if(callback) {
+        callback(data);
+      }
+    }).fail(function(xhr, status, err) {
+      if(error) {
+        error();
+      }
+    });
+  }
+  
+  function remove(rno, callback, error) {
+    $.ajax({
+      type : 'delete',
+      url : '/replies/' + rno,
+      success : function(deleteResult, status, xhr) {
+        if(callback) {
+          callback(deleteResult);
+        }
+      },
+      error : function(xhr, status, er) {
+        if(error) {
+          error(er);
+        }
+      }
+    });
+  }
+  
+  function update(reply, callback, error) {
+    console.log("RNO: " + reply.rno);
+    
+    $.ajax({
+      type : 'put',
+      url : '/replies/' + reply.rno,
+      data : JSON.stringify(reply),
+      contentType : "application/json; charset=utf-8",
+      success : function(result, status, xhr) {
+        if(callback) {
+          callback(result);
+        }
+      },
+      error: function(xhr, status, er) {
+        if(error) {
+          error(er);
+        }
+      }
+    });
+  }
+  
+  function get(rno, callback, error) {
+    $.get("/replies/" + rno + ".json", function(result) {
+      if(callback) {
+        callback(result);
+      }
+    }).fail(function(xhr, status, err) {
+      if(error) {
+        error();
+      }
+    });
+  }
+  
+  function displayTime(timeValue) {
+    var today = new Date();
+    var gap = today.getTime() - timeValue;
+    var dateObj = new Date(timeValue);
+    var str = "";
+    /* 24시간이 안지난 댓글 */
+    if(gap < (1000 * 60 * 60 * 24)) {
+      var hh = dateObj.getHours();
+      var mi = dateObj.getMinutes();
+      var ss = dateObj.getSeconds();
+      
+      return [(hh > 9 ? '' : '0') + hh, ':', (mi > 9 ? '' : '0') + mi, ':', (ss > 9 ? '' : '0') + ss].join('');
+    } else {
+      var yy = dateObj.getFullYear();
+      var mm = dateObj.getMonth() + 1; // getMonth()는 0부터 시작한다
+      var dd = dateObj.getDate();
+      
+      return [yy, '/', (mm > 9 ? '' : '0') + mm, '/', (dd > 9 ? '' : '0') + dd].join('');
+    }
+  }
+  
+  return {
+    add:add,
+    getList:getList,
+    remove:remove,
+    update:update,
+    get: get,
+    displayTime : displayTime
+  };
+})();


### PR DESCRIPTION
* Ajax, REST 방식으로 댓글 CRUD 처리
* ReplyController 설계

|작업|URL|HTTP 전송방식|
|------|---|---|
|등록|/replies/new|POST|
|조회|/replies/:rno|GET|
|삭제|/replier/:rno|DELETE|
|수정|/replier/:rno|PUT or PATCH|
|페이지|/replier/pages/:bno/:page|GET|

* JSP에서의 댓글 CRUD 처리
  * JavaScript의 모듈 패턴  이용
    * 즉시 실행함수를 이용하여 replyService 객체의 메소드 추가
     
|작업|replyService의 메소드|
|------|---|
|등록|add()|
|조회|get()|
|삭제|remove()|
|수정|update()|
|목록|getList()|
