### PR TITLE
feat: 게시판 댓글 등록/삭제 시 트랜잭션 처리

### DIFF
--- a/src/main/java/com/cgkim449/app/domain/BoardVO.java
+++ b/src/main/java/com/cgkim449/app/domain/BoardVO.java
@@ -11,4 +11,6 @@ public class BoardVO {
   private String writer;
   private Date regdate;
   private Date updateDate;
+
+  private int replyCnt;
 }

--- a/src/main/java/com/cgkim449/app/mapper/BoardMapper.java
+++ b/src/main/java/com/cgkim449/app/mapper/BoardMapper.java
@@ -1,6 +1,7 @@
 package com.cgkim449.app.mapper;
 
 import java.util.List;
+import org.apache.ibatis.annotations.Param;
 import com.cgkim449.app.domain.BoardVO;
 import com.cgkim449.app.domain.Criteria;
 
@@ -18,4 +19,6 @@ public interface BoardMapper {
   public List<BoardVO> getListWithPaging(Criteria cri);
 
   public int getTotalCount(Criteria cri);
+
+  public void updateReplyCnt(@Param("bno") Long bno, @Param("amount") int amount);
 }

--- a/src/main/java/com/cgkim449/app/service/ReplyServiceImpl.java
+++ b/src/main/java/com/cgkim449/app/service/ReplyServiceImpl.java
@@ -1,14 +1,14 @@
 package com.cgkim449.app.service;
 
 import java.util.List;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import com.cgkim449.app.domain.Criteria;
 import com.cgkim449.app.domain.ReplyPageDTO;
 import com.cgkim449.app.domain.ReplyVO;
+import com.cgkim449.app.mapper.BoardMapper;
 import com.cgkim449.app.mapper.ReplyMapper;
 import lombok.AllArgsConstructor;
-import lombok.Setter;
 import lombok.extern.log4j.Log4j;
 
 @Service
@@ -17,10 +17,13 @@ import lombok.extern.log4j.Log4j;
 public class ReplyServiceImpl implements ReplyService{
 
   private ReplyMapper mapper;
+  private BoardMapper boardMapper;
 
+  @Transactional
   @Override
   public int register(ReplyVO vo) {
     log.info("register..." + vo);
+    boardMapper.updateReplyCnt(vo.getBno(), 1);
     return mapper.insert(vo);
   }
 
@@ -36,9 +39,13 @@ public class ReplyServiceImpl implements ReplyService{
     return mapper.update(vo);
   }
 
+  @Transactional
   @Override
   public int remove(Long rno) {
     log.info("remove..."+rno);
+    ReplyVO vo = mapper.read(rno);
+
+    boardMapper.updateReplyCnt(vo.getBno(), -1);
     return mapper.delete(rno);
   }
 

--- a/src/main/resources/com/cgkim449/app/mapper/BoardMapper.xml
+++ b/src/main/resources/com/cgkim449/app/mapper/BoardMapper.xml
@@ -5,25 +5,25 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 
 <mapper namespace="com.cgkim449.app.mapper.BoardMapper">
 
-<sql id="criteria">
-<trim prefix="(" suffix=") AND " prefixOverrides="OR">
- <foreach item="type" collection="typeArr">
-   <trim prefix="OR">
-     <choose>
-       <when test="type=='T'.toString()">
-         title like '%'||#{keyword}||'%'
-       </when>
-       <when test="type=='C'.toString()">
-         content like '%'||#{keyword}||'%'
-       </when>
-       <when test="type=='W'.toString()">
-         writer like '%'||#{keyword}||'%'
-       </when>
-     </choose>
-   </trim>
- </foreach>
-</trim>
-</sql>
+	<sql id="criteria">
+		<trim prefix="(" suffix=") AND " prefixOverrides="OR">
+			<foreach item="a" collection="typeArr">
+				<trim prefix="OR">
+					<choose>
+						<when test="a=='T'.toString()">
+							title like '%'||#{keyword}||'%'
+						</when>
+						<when test="a=='C'.toString()">
+							content like '%'||#{keyword}||'%'
+						</when>
+						<when test="a=='W'.toString()">
+							writer like '%'||#{keyword}||'%'
+						</when>
+					</choose>
+				</trim>
+			</foreach>
+		</trim>
+	</sql>
 
 	<select id="getList"
 		resultType="com.cgkim449.app.domain.BoardVO">
@@ -46,11 +46,13 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		</selectKey>
 
 		insert into tbl_board (bno, title, content, writer)
-		values (#{bno}, #{title}, #{content}, #{writer})
+		values (#{bno},
+		#{title}, #{content}, #{writer})
 	</insert>
 
 	<select id="read" resultType="com.cgkim449.app.domain.BoardVO">
-		select * from tbl_board where bno=#{bno}
+		select * from tbl_board where
+		bno=#{bno}
 	</select>
 
 	<delete id="delete">
@@ -62,39 +64,45 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		content=#{content},
 		writer=#{writer},
 		updateDate=sysdate
-		where bno = #{bno}
+		where bno =
+		#{bno}
 	</update>
-	
-  <select id="getListWithPaging" resultType="com.cgkim449.app.domain.BoardVO">
+
+	<select id="getListWithPaging"
+		resultType="com.cgkim449.app.domain.BoardVO">
 	  <![CDATA[
 	  select 
-	    bno, title, content, writer, regdate, updatedate
+	    bno, title, content, writer, regdate, updatedate, replycnt
 	  from 
 	      (
 	      select /*+INDEX_DESC(tbl_board pk_board) */
-	        rownum rn, bno, title, content, writer, regdate, updatedate 
+	        rownum rn, bno, title, content, writer, regdate, updatedate, replycnt 
 	      from 
 	        tbl_board
 	      where 
 	      ]]>
-	      
-	      <include refid="criteria"></include>
+
+		<include refid="criteria"></include>
 	      
 	      <![CDATA[
 	      rownum <= #{pageNum} * #{amount}
 	      )
 	      where rn > (#{pageNum} - 1) * #{amount}
 	  ]]>
-  </select>
-	<!-- 현재페이지(pageNum)이 1이면 rn은 위부터 차례대로 20, 10 이다 -->
-	
-	
-	<select id="getTotalCount" resultType="int">
-	 select count(*) from tbl_board 
-	 where 
-	 
-	 
-	 bno > 0
 	</select>
-	
+	<!-- 현재페이지(pageNum)이 1이면 rn은 위부터 차례대로 20, 10 이다 -->
+
+
+	<select id="getTotalCount" resultType="int">
+		select count(*) from tbl_board
+		where
+
+
+		bno > 0
+	</select>
+
+  <update id="updateReplyCnt">
+    update tbl_board set replycnt = replycnt + #{amount} where bno = #{bno}
+  </update>
+
 </mapper>

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -34,7 +34,7 @@
 
 	<!-- Root Logger -->
 	<root>
-		<priority value="warn" />
+		<priority value="info" />
 		<appender-ref ref="console" />
 	</root>
 	

--- a/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -1,32 +1,48 @@
-<?xml version="1.0" encoding="UTF-8"?> 
+<?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:context="http://www.springframework.org/schema/context"
-  xmlns:mybatis-spring="http://mybatis.org/schema/mybatis-spring"
-  xsi:schemaLocation="http://mybatis.org/schema/mybatis-spring http://mybatis.org/schema/mybatis-spring-1.2.xsd
-    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd">
-  
-   <!-- Root Context: defines shared resources visible to all other web components -->
-  <bean id="hikariConfig" class="com.zaxxer.hikari.HikariConfig">
-    <property name="driverClassName"
-    value = "net.sf.log4jdbc.sql.jdbcapi.DriverSpy"></property>
-    <property name="jdbcUrl"  value="jdbc:log4jdbc:oracle:thin:@localhost:1521:XE"></property>
-    <property name="username" value="sf"></property>
-    <property name="password" value="sf"></property>
-  </bean>
-  <!-- HikariCP configuration -->
-  <bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource"
-    destroy-method="close">
-    <constructor-arg ref="hikariConfig" />
-  </bean>
-  
-  <bean id="sqlSessionFactory" class = "org.mybatis.spring.SqlSessionFactoryBean">
-    <property name="dataSource" ref = "dataSource"></property>
-  </bean>
-  
-  <mybatis-spring:scan base-package="com.cgkim449.app.mapper"/>
-  
-  <context:component-scan base-package="com.cgkim449.app.service"></context:component-scan>
-  
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:mybatis-spring="http://mybatis.org/schema/mybatis-spring"
+	xmlns:tx="http://www.springframework.org/schema/tx"
+	xmlns:aop="http://www.springframework.org/schema/aop"
+	xsi:schemaLocation="http://mybatis.org/schema/mybatis-spring http://mybatis.org/schema/mybatis-spring-1.2.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd
+		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.3.xsd
+		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.3.xsd">
+
+	<!-- Root Context: defines shared resources visible to all other web components -->
+	<bean id="hikariConfig" class="com.zaxxer.hikari.HikariConfig">
+		<property name="driverClassName"
+			value="net.sf.log4jdbc.sql.jdbcapi.DriverSpy"></property>
+		<property name="jdbcUrl"
+			value="jdbc:log4jdbc:oracle:thin:@localhost:1521:XE"></property>
+		<property name="username" value="sf"></property>
+		<property name="password" value="sf"></property>
+	</bean>
+	<!-- HikariCP configuration -->
+	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource"
+		destroy-method="close">
+		<constructor-arg ref="hikariConfig" />
+	</bean>
+
+	<bean id="sqlSessionFactory"
+		class="org.mybatis.spring.SqlSessionFactoryBean">
+		<property name="dataSource" ref="dataSource"></property>
+	</bean>
+
+	<bean id="transactionManager"
+		class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+		<property name="dataSource" ref="dataSource"></property>
+	</bean>
+
+  <tx:annotation-driven/>
+
+	<mybatis-spring:scan
+		base-package="com.cgkim449.app.mapper" />
+
+	<context:component-scan
+		base-package="com.cgkim449.app.service"></context:component-scan>
+
+
 </beans>

--- a/src/main/webapp/WEB-INF/views/board/list.jsp
+++ b/src/main/webapp/WEB-INF/views/board/list.jsp
@@ -101,7 +101,12 @@ $(document).ready(function() {
 		<c:forEach items="${list}" var="board">
 		  <tr>
 		    <td><c:out value="${board.bno}"/></td>
-		    <td><a class='move' href='<c:out value="${board.bno}"/>'><c:out value="${board.title}"/></a></td>
+		    <td>
+			    <a class='move' href='<c:out value="${board.bno}"/>'>
+			     <c:out value="${board.title}"/>
+			     <b>[<c:out value="${board.replyCnt}"/>]</b>
+			    </a>
+		    </td>
 		    <td><c:out value="${board.writer}"/></td>
 		    <td><fmt:formatDate pattern="yyyy-MM-dd" value="${board.regdate}"/></td>
 		    <td><fmt:formatDate pattern="yyyy-MM-dd" value="${board.updateDate}"/></td>


### PR DESCRIPTION
* 댓글 등록/삭제시 tbl_reply 테이블에 insert하고, tbl_board 테이블에 댓글의 수를 update해야함
  * ReplyService에 트랜잭션 처리
* transactionManager 빈 등록, 어노테이션 기반으로 트랜잭션 설정하는 태그 `<tx:annotation-driven/>` 등록
* tbl_board 테이블 수정
  * replyCnt 컬럼 추가
    * `alter table tbl_board add(replycnt number default 0);`
  * 기존에 댓글이 존재했던 게시물들 replyCnt값 업데이트
    * `update tbl_board set replycnt = (select count(rno) from tbl_reply where tbl_reply.bno = tbl_board.bno);`
* 게시물의 댓글 수를 데이터베이스에 update하는 메서드 추가
* 게시물 목록 화면에 각 게시물에 달린 댓글 숫자 출력